### PR TITLE
Fix scroller handle position is not preserved bug  (issue #3)

### DIFF
--- a/Application/src/main/java/com/example/recyclerviewfastscroller/ui/scroller/AbsRecyclerViewFastScroller.java
+++ b/Application/src/main/java/com/example/recyclerviewfastscroller/ui/scroller/AbsRecyclerViewFastScroller.java
@@ -189,6 +189,24 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
         return mOnScrollListener;
     }
 
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        if (getScrollProgressCalculator() == null) {
+            onCreateScrollProgressCalculator();
+        }
+
+        // synchronize the handle position to the RecyclerView
+        float scrollProgress = getScrollProgressCalculator().calculateScrollProgress(mRecyclerView);
+        moveHandleToPosition(scrollProgress);
+    }
+
+    /**
+     * Sub classes have to override this method and create the ScrollProgressCalculator instance in this method.
+     */
+    protected abstract void onCreateScrollProgressCalculator();
+
     /**
      * Takes a touch event and determines how much scroll progress this translates into
      * @param event touch event received by the layout

--- a/Application/src/main/java/com/example/recyclerviewfastscroller/ui/scroller/vertical/VerticalRecyclerViewFastScroller.java
+++ b/Application/src/main/java/com/example/recyclerviewfastscroller/ui/scroller/vertical/VerticalRecyclerViewFastScroller.java
@@ -50,15 +50,10 @@ public class VerticalRecyclerViewFastScroller extends AbsRecyclerViewFastScrolle
         mHandle.setY(mScreenPositionCalculator.getYPositionFromScrollProgress(scrollProgress));
     }
 
-    @Override
-    public void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (mScrollProgressCalculator == null || mScreenPositionCalculator == null) {
-            VerticalScrollBoundsProvider boundsProvider =
-                    new VerticalScrollBoundsProvider(mBar.getY(), mBar.getY() + mBar.getHeight() - mHandle.getHeight());
-            mScrollProgressCalculator = new VerticalLinearLayoutManagerScrollProgressCalculator(boundsProvider);
-            mScreenPositionCalculator = new VerticalScreenPositionCalculator(boundsProvider);
-        }
+    protected void onCreateScrollProgressCalculator() {
+        VerticalScrollBoundsProvider boundsProvider =
+                new VerticalScrollBoundsProvider(mBar.getY(), mBar.getY() + mBar.getHeight() - mHandle.getHeight());
+        mScrollProgressCalculator = new VerticalLinearLayoutManagerScrollProgressCalculator(boundsProvider);
+        mScreenPositionCalculator = new VerticalScreenPositionCalculator(boundsProvider);
     }
-
 }


### PR DESCRIPTION
This PR fixes the issue #3.

The key point:
- Add the moveHandleToPosition() method call in onLayout() method of scroller
