### PR TITLE
Update AbsRecyclerViewFastScroller.java

### DIFF
--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -182,8 +182,12 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
             mOnScrollListener = new OnScrollListener() {
                 @Override
                 public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                    float scrollProgress = getScrollProgressCalculator().calculateScrollProgress(recyclerView);
-                    moveHandleToPosition(scrollProgress);
+                    TouchableScrollProgressCalculator scrollProgressCalculator = getScrollProgressCalculator();
+                    if (scrollProgressCalculator != null) {
+                        float scrollProgress = scrollProgressCalculator.calculateScrollProgress(recyclerView);
+
+                        moveHandleToPosition(scrollProgress);
+                    }
                 }
             };
         }


### PR DESCRIPTION
fix the bug when using appcompatv7 ActionBarActivity, the program crashes because getScrollProgressCalculator() returns null
