### PR TITLE
fix GridLayoutManager and StaggeredGridLayoutManager scroller bar

### DIFF
--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/calculation/progress/VerticalLinearLayoutManagerScrollProgressCalculator.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/calculation/progress/VerticalLinearLayoutManagerScrollProgressCalculator.java
@@ -1,11 +1,15 @@
 package xyz.danoz.recyclerviewfastscroller.calculation.progress;
 
-import xyz.danoz.recyclerviewfastscroller.calculation.VerticalScrollBoundsProvider;
-
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.View;
+
+import java.util.Arrays;
+
+import xyz.danoz.recyclerviewfastscroller.calculation.VerticalScrollBoundsProvider;
 
 /**
  * Calculates scroll progress for a {@link RecyclerView} with a {@link LinearLayoutManager}
@@ -22,8 +26,26 @@ public class VerticalLinearLayoutManagerScrollProgressCalculator extends Vertica
      */
     @Override
     public float calculateScrollProgress(RecyclerView recyclerView) {
-        LinearLayoutManager layoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
-        int lastFullyVisiblePosition = layoutManager.findLastCompletelyVisibleItemPosition();
+
+        RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+
+        int spanCount = 1;
+        int lastFullyVisiblePosition = 0;
+
+        if (layoutManager instanceof GridLayoutManager) {
+            spanCount = ((GridLayoutManager) layoutManager).getSpanCount();
+        }
+
+        if (layoutManager instanceof LinearLayoutManager) {
+            lastFullyVisiblePosition = ((LinearLayoutManager) layoutManager).
+                    findLastCompletelyVisibleItemPosition();
+        } else if (layoutManager instanceof StaggeredGridLayoutManager) {
+            int[] into = ((StaggeredGridLayoutManager) layoutManager).
+                    findLastCompletelyVisibleItemPositions(null);
+            Arrays.sort(into);
+            lastFullyVisiblePosition = into[into.length - 1];
+            spanCount = ((StaggeredGridLayoutManager) layoutManager).getSpanCount();
+        }
 
         View visibleChild = recyclerView.getChildAt(0);
         if (visibleChild == null) {
@@ -32,7 +54,7 @@ public class VerticalLinearLayoutManagerScrollProgressCalculator extends Vertica
         ViewHolder holder = recyclerView.getChildViewHolder(visibleChild);
         int itemHeight = holder.itemView.getHeight();
         int recyclerHeight = recyclerView.getHeight();
-        int itemsInWindow = recyclerHeight / itemHeight;
+        int itemsInWindow = (recyclerHeight / itemHeight) * spanCount;
 
         int numItemsInList = recyclerView.getAdapter().getItemCount();
         int numScrollableSectionsInList = numItemsInList - itemsInWindow;


### PR DESCRIPTION
GridLayoutManager's fast scroller bar has a big offset, and StaggeredGridLayoutManager may case crash.

Screenshots attached:

**before**
![before](https://cloud.githubusercontent.com/assets/2604211/7805795/63c71976-03ab-11e5-8236-02494d5061ab.png)

**fixed**
![fixed](https://cloud.githubusercontent.com/assets/2604211/7805801/8437ced0-03ab-11e5-8d97-e06c216d0a97.png)

And the class name "VerticalLinearLayoutManagerScrollProgressCalculator" can be changed to "VerticalLayoutManagerScrollProgressCalculator" now.
