### PR TITLE
Added refreshing bar height in onLayout

### DIFF
--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -198,9 +198,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
 
-        if (getScrollProgressCalculator() == null) {
-            onCreateScrollProgressCalculator();
-        }
+        onCreateScrollProgressCalculator();
 
         // synchronize the handle position to the RecyclerView
         float scrollProgress = getScrollProgressCalculator().calculateScrollProgress(mRecyclerView);

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/calculation/VerticalScrollBoundsProvider.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/calculation/VerticalScrollBoundsProvider.java
@@ -5,8 +5,8 @@ package xyz.danoz.recyclerviewfastscroller.calculation;
  */
 public class VerticalScrollBoundsProvider {
 
-    private final float mMinimumScrollY;
-    private final float mMaximumScrollY;
+    private float mMinimumScrollY;
+    private float mMaximumScrollY;
 
     public VerticalScrollBoundsProvider(float minimumScrollY, float maximumScrollY) {
         mMinimumScrollY = minimumScrollY;
@@ -19,5 +19,10 @@ public class VerticalScrollBoundsProvider {
 
     public float getMaximumScrollY() {
         return mMaximumScrollY;
+    }
+
+    public void update(float minimumScrollY, float maximumScrollY) {
+        mMinimumScrollY = minimumScrollY;
+        mMaximumScrollY = maximumScrollY;
     }
 }

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/vertical/VerticalRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/vertical/VerticalRecyclerViewFastScroller.java
@@ -1,6 +1,7 @@
 package xyz.danoz.recyclerviewfastscroller.vertical;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -21,8 +22,9 @@ import xyz.danoz.recyclerviewfastscroller.calculation.progress.VerticalScrollPro
  */
 public class VerticalRecyclerViewFastScroller extends AbsRecyclerViewFastScroller implements RecyclerViewScroller {
 
-    @Nullable private VerticalScrollProgressCalculator mScrollProgressCalculator;
-    @Nullable private VerticalScreenPositionCalculator mScreenPositionCalculator;
+    private VerticalScrollProgressCalculator mScrollProgressCalculator;
+    private VerticalScreenPositionCalculator mScreenPositionCalculator;
+    private VerticalScrollBoundsProvider boundsProvider;
 
     public VerticalRecyclerViewFastScroller(Context context) {
         this(context, null);
@@ -34,6 +36,13 @@ public class VerticalRecyclerViewFastScroller extends AbsRecyclerViewFastScrolle
 
     public VerticalRecyclerViewFastScroller(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        boundsProvider = new VerticalScrollBoundsProvider(mBar.getY(), mBar.getY() + mBar.getHeight() - mHandle.getHeight());
+        mScrollProgressCalculator = new VerticalLinearLayoutManagerScrollProgressCalculator(boundsProvider);
+        mScreenPositionCalculator = new VerticalScreenPositionCalculator(boundsProvider);
     }
 
     @Override
@@ -55,10 +64,8 @@ public class VerticalRecyclerViewFastScroller extends AbsRecyclerViewFastScrolle
         mHandle.setY(mScreenPositionCalculator.getYPositionFromScrollProgress(scrollProgress));
     }
 
+    @Override
     protected void onCreateScrollProgressCalculator() {
-        VerticalScrollBoundsProvider boundsProvider =
-                new VerticalScrollBoundsProvider(mBar.getY(), mBar.getY() + mBar.getHeight() - mHandle.getHeight());
-        mScrollProgressCalculator = new VerticalLinearLayoutManagerScrollProgressCalculator(boundsProvider);
-        mScreenPositionCalculator = new VerticalScreenPositionCalculator(boundsProvider);
+        boundsProvider.update(mBar.getY(), mBar.getY() + mBar.getHeight() - mHandle.getHeight());
     }
 }


### PR DESCRIPTION
Hi ! There was an issue in our project that sometimes we weren't able to move bar handle to
the bottom of the bar. I discovered it was caused by "onCreateScrollProgressCalculator" method
which is called only once in onLayout method, but bar height was changing in subsequent onLayout calls. That caused VerticalScrollProgressCalculator and VerticalScreenPositionCalculator to use wrong bar height.

I broke your immutable VerticalScrollBoundsProvider class so it have update method now. IMHO it is better solution for view efficiency than creating new objects in on layout.