### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As of [`b3e2d2f`](https://github.com/danoz73/RecyclerViewFastScroller/commit/b3e
 
 You can grab the current version of the library from maven central
 ```java
-compile 'xyz.danoz:recyclerviewfastscroller:0.1.3'
+implementation 'xyz.danoz:recyclerviewfastscroller:0.1.3'
 ```
 
 ### Usage


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.